### PR TITLE
Configurable signature header name

### DIFF
--- a/output-worker/src/main.rs
+++ b/output-worker/src/main.rs
@@ -73,7 +73,7 @@ struct Config {
     #[clap(long, env, value_parser = humantime::parse_duration, default_value = "15s")]
     timeout: Duration,
 
-    /// Signature Header name
+    /// Name of the header containing webhook's signature
     #[clap(long, env, default_value = "X-Hook0-Signature")]
     signature_header_name: HeaderName,
 }

--- a/output-worker/src/main.rs
+++ b/output-worker/src/main.rs
@@ -4,7 +4,7 @@ mod work;
 use chrono::{DateTime, Utc};
 use clap::{crate_name, crate_version, Parser};
 use log::{debug, error, info, trace, warn};
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, HeaderName};
 use reqwest::Url;
 use sqlx::postgres::types::PgInterval;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
@@ -72,6 +72,10 @@ struct Config {
     /// Timeout for obtaining a HTTP response from the target, including connect phase (if exceeded, request attempt will fail)
     #[clap(long, env, value_parser = humantime::parse_duration, default_value = "15s")]
     timeout: Duration,
+
+    /// Signature Header name
+    #[clap(long, env, default_value = "X-Hook0-Signature")]
+    signature_header_name: HeaderName,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/output-worker/src/work.rs
+++ b/output-worker/src/work.rs
@@ -184,7 +184,7 @@ pub async fn work(config: &Config, attempt: &RequestAttempt) -> Response {
             headers.insert("Content-Type", content_type);
             headers.insert("X-Event-Id", event_id);
             headers.insert("X-Event-Type", et);
-            headers.insert("X-Hook0-Signature", sig);
+            headers.insert(&config.signature_header_name, sig);
 
             debug!("Calling webhook...");
             trace!(


### PR DESCRIPTION
We'd like to use a generic header (e.g. `X-Signature`) rather than having hook0 in the header name.

This adds a config to the worker to set the header name, defaulting to the existing hardcoded value.

I thought about making it configurable per organisation/application/subscription or something, but this was a lot easier! (and meets our needs for now).