### PR TITLE
Fix concurrent / multi-platform Docker builds

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,8 +9,8 @@ RUN --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=clients/rust,target=clients/rust \
     --mount=type=bind,source=output-worker,target=output-worker \
     --mount=type=bind,source=sentry-integration,target=sentry-integration \
-    --mount=type=cache,target=/app/target/ \
-    --mount=type=cache,target=/usr/local/cargo/registry/ \
+    --mount=type=cache,sharing=private,target=/app/target/ \
+    --mount=type=cache,sharing=private,target=/usr/local/cargo/registry/ \
     <<EOF
 set -e
 cd api || exit 1
@@ -19,7 +19,7 @@ cd .. || exit 1
 cp ./target/release/hook0-api /
 EOF
 
-FROM debian:12
+FROM debian:12-slim
 ARG UID=10001
 RUN adduser \
     --disabled-password \

--- a/output-worker/Dockerfile
+++ b/output-worker/Dockerfile
@@ -8,8 +8,8 @@ RUN --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=clients/rust,target=clients/rust \
     --mount=type=bind,source=output-worker,target=output-worker \
     --mount=type=bind,source=sentry-integration,target=sentry-integration \
-    --mount=type=cache,target=/app/target/ \
-    --mount=type=cache,target=/usr/local/cargo/registry/ \
+    --mount=type=cache,sharing=private,target=/app/target/ \
+    --mount=type=cache,sharing=private,target=/usr/local/cargo/registry/ \
     <<EOF
 set -e
 cd output-worker || exit 1
@@ -18,7 +18,7 @@ cd .. || exit 1
 cp ./target/release/hook0-output-worker /
 EOF
 
-FROM debian:12
+FROM debian:12-slim
 ARG UID=10001
 RUN adduser \
     --disabled-password \


### PR DESCRIPTION
Cargo builds can block or fail when running concurrently due to the cache mounts.
This doesn't manifest if you're just doing basic builds like `docker build -t hook0-api -f api/Dockerfile .`
But is a problem if you try to build multi-platform images (e.g. `docker buildx build --platform linux/arm64/v8,linux/amd64 -t hook0-api -f api/Dockerfile .`)

You get errors like

```
3.173 error: failed to unpack package `itertools v0.10.5`
3.173
3.173 Caused by:
3.173   failed to open `/usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/itertools-0.10.5/.cargo-ok`
3.173
3.173 Caused by:
3.173   File exists (os error 17)
```

Or sometimes 1 of the builds blocks until the other completes
```
 => => #   Downloaded paperclip v0.9.4
 => => #     Blocking waiting for file lock on build directory
```

Use private mode to prevent this
https://docs.docker.com/reference/dockerfile/#run---mounttypecache
> A shared cache mount can be used concurrently by multiple writers. private creates a new mount if there are multiple writers.

Also switches the final image to `debian:12-slim`, saves about 20MB off my images, not huge but every little bit helps! :)