### PR TITLE
Improvement: change API_ENDPOINT from ENV to ARG in Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ ARG CADDY_VERSION=2.9
 
 FROM node:${NODE_VERSION} AS build
 WORKDIR /app
-ENV API_ENDPOINT http://localhost:8081/api/v1
+ARG API_ENDPOINT http://localhost:8081/api/v1
 COPY frontend/ ./
 RUN --mount=type=bind,source=mediakit,target=/mediakit \
     rm -rf -- dist/ && npm ci && npm run build


### PR DESCRIPTION
This PR updates the frontend Dockerfile to allow overriding the API endpoint address during the build stage.
In my case it was to allow using a different port, as 8081 was already used in my dev stack.