### PR TITLE
fix(api,output-worker): add protoc and protobuf mount to Docker build

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,12 +3,16 @@ ARG RUST_VERSION=1.90
 FROM rust:${RUST_VERSION} AS builder-rust
 WORKDIR /app
 ARG FEATURES=""
+
+RUN apt-get update && apt-get install -y protobuf-compiler
+
 RUN --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
     --mount=type=bind,source=api,target=api \
     --mount=type=bind,source=clients/rust,target=clients/rust \
     --mount=type=bind,source=output-worker,target=output-worker \
     --mount=type=bind,source=sentry-integration,target=sentry-integration \
+    --mount=type=bind,source=protobuf,target=protobuf \
     --mount=type=cache,sharing=private,target=/app/target/ \
     --mount=type=cache,sharing=private,target=/usr/local/cargo/registry/ \
     <<EOF

--- a/output-worker/Dockerfile
+++ b/output-worker/Dockerfile
@@ -2,12 +2,16 @@ ARG RUST_VERSION=1.90
 
 FROM rust:${RUST_VERSION} AS builder-rust
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y protobuf-compiler
+
 RUN --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
     --mount=type=bind,source=api,target=api \
     --mount=type=bind,source=clients/rust,target=clients/rust \
     --mount=type=bind,source=output-worker,target=output-worker \
     --mount=type=bind,source=sentry-integration,target=sentry-integration \
+    --mount=type=bind,source=protobuf,target=protobuf \
     --mount=type=cache,sharing=private,target=/app/target/ \
     --mount=type=cache,sharing=private,target=/usr/local/cargo/registry/ \
     <<EOF


### PR DESCRIPTION
This change fixes the Docker build of the API and Output Worker, as they fail to build because the hook0-protobuf project is missing