### PR TITLE
Fix docker builds missing context

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get install -y protobuf-compiler
 RUN --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
     --mount=type=bind,source=api,target=api \
+    --mount=type=bind,source=cli,target=cli \
+    --mount=type=bind,source=play,target=play \
     --mount=type=bind,source=clients/rust,target=clients/rust \
     --mount=type=bind,source=clients/mcp,target=clients/mcp \
     --mount=type=bind,source=output-worker,target=output-worker \

--- a/frontend/Dockerfile.dockerignore
+++ b/frontend/Dockerfile.dockerignore
@@ -1,0 +1,13 @@
+.env
+target/
+.git/
+api/
+cli/
+output-worker/
+frontend/node_modules/
+play/
+documentation/
+website/
+e2e-tests/
+.gitlab-ci.yml
+*.md

--- a/output-worker/Dockerfile
+++ b/output-worker/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y protobuf-compiler
 RUN --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
     --mount=type=bind,source=api,target=api \
+    --mount=type=bind,source=cli,target=cli \
+    --mount=type=bind,source=play,target=play \
     --mount=type=bind,source=clients/rust,target=clients/rust \
     --mount=type=bind,source=clients/mcp,target=clients/mcp \
     --mount=type=bind,source=output-worker,target=output-worker \


### PR DESCRIPTION
Recently the docker builds have stopped working for me,

Frontend was being ignored by the root docker ignore, this adds a frontend specific ignore to avoid having a large context for all builds

Output worker and API were failing with issues accessing the cargo files from cli and play directories.

All builds now pass with `docker compose build` 