### PR TITLE
fix(readme): point the star history chart to a working mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ limitations:
 © Hook0 SAS
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hook0/hook0&type=Date)](https://www.star-history.com/#hook0/hook0&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hook0/hook0&type=Date)](https://star-history.dera.page/#hook0/hook0&Date)


### PR DESCRIPTION
The Star History chart in the README is currently broken due to GitHub stargazer API restrictions, so the chart no longer renders. This change points the chart, and its wrapping link, to a mirror that uses a different data source and does not require an API token. The badge is left untouched.